### PR TITLE
Some plugins tests needs redis to be installed

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -49,6 +49,9 @@ export PATH=$PATH:/usr/local/bin:/usr/local/openresty/bin
 # Adjust PATH for future ssh
 echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin" >> /home/vagrant/.bashrc
 
+sudo apt-get install redis-server
+sudo chown vagrant /var/log/redis/redis-server.log
+
 # Set higher ulimit
 sudo bash -c 'echo "fs.file-max = 65536" >> /etc/sysctl.conf'
 sudo sysctl -p


### PR DESCRIPTION
Some plugins tests needs redis to be installed, with the right permis…sions on /var/log/redis/redis-server.log

#ci Plugin: rate-limiting (access) with policy: local setup
spec/03-plugins/98-rate-limiting/04-access_spec.lua:28: bad argument #2 to 'error' (number expected, got string)

stack traceback:
        spec/03-plugins/98-rate-limiting/04-access_spec.lua:28: in function 'flush_redis'
        spec/03-plugins/98-rate-limiting/04-access_spec.lua:46: in function <spec/03-plugins/98-rate-limiting/04-access_spec.lua:44>

 Failure → spec/03-plugins/005-syslog/01-log_spec.lua @ 99
        #ci Plugin: syslog (log) logs to syslog if log_level is lower
        spec/03-plugins/005-syslog/01-log_spec.lua:94: grep: /var/log/redis/redis-server.log: Permission denied

stack traceback:
                ./kong/core/globalpatches.lua:158: in function 'assert'
                spec/03-plugins/005-syslog/01-log_spec.lua:94: in function 'do_test'
                spec/03-plugins/005-syslog/01-log_spec.lua:100: in function <spec/03-plugins/005-syslog/01-log_spec.lua:99>

        Failure → spec/03-plugins/005-syslog/01-log_spec.lua @ 105
        #ci Plugin: syslog (log) logs to syslog if log_level is the same
        spec/03-plugins/005-syslog/01-log_spec.lua:94: grep: /var/log/redis/redis-server.log: Permission denied